### PR TITLE
ユーザページの改善

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -6,7 +6,9 @@
 
 $button: rgba(156, 206, 94, 0.78);
 
+/*************/
 /* universal */
+/*************/
 
 div#wrapper {
   position: relative;
@@ -22,7 +24,9 @@ div#wrapper {
   }
 }
 
+/**************/
 /* typography */
+/**************/
 
 //要検討
 body {
@@ -32,7 +36,7 @@ body {
     "Hiragino Sans",
     Meiryo,
     sans-serif;
-  background-color: #ecececfd;
+  background-color: #e9e9e9;
   -webkit-text-size-adjust: 100%;
 }
 
@@ -62,7 +66,9 @@ p {
 
 em { font-style: normal }
 
-/* header */
+/*************/
+/*  header  */
+/************/
 
 header {
   width: 100%;
@@ -85,7 +91,9 @@ header {
   }
 }
 
-/* flash */
+/***********/
+/*  flash  */
+/***********/
 
 .notice {
   padding: 0.6rem 0.4rem;
@@ -107,14 +115,16 @@ header {
   border-radius: 0;
 }
 
-
+/*************/
 /* container */
+/*************/
 
 #container {
   padding: 2em 0;
 
-
-/* form */
+/**********/
+/*  form  */
+/**********/
 
   .form-container {
     background: #fff;
@@ -312,12 +322,14 @@ header {
   }
 }
 
-
+/***************/
 /* Users index */
+/***************/
 
 .users {
-  margin: 1.5em 0;
+  margin: 1.5em auto;
   list-style: none;
+  max-width: 1050px;
   li {
     padding-right: 8px;
     padding-left: 8px;
@@ -347,22 +359,39 @@ header {
         height:100%;
         width: 100%;
         text-decoration: none;
-        text-indent:-999px;
+        text-indent:-9999px;
         z-index: 2;
         pointer-events: auto;
       }
       .nickname {
         position: absolute;
         top: 10px; 
-        left: 90px;
+        left: 100px;
         font-size: 1.2em;
         color: #2499cf;
       }
       .follow {
         position: absolute;
-        bottom: 10px;
-        left: 90px;
+        bottom: 30px;
+        left: 100px;
         font-size: 0.95em;
+        span {
+          font-size: 1.1em;
+          font-weight: 400;
+          &.pad-r10 {
+            padding-right: 10px;
+          }
+        }
+      }
+      .post {
+        position: absolute;
+        bottom: 8px;
+        left: 100px;
+        font-size: 0.95em;
+        span {
+          font-size: 1.1em;
+          font-weight: 400;
+        }
       }
     }
   }
@@ -384,20 +413,9 @@ header {
   }
 }
 
-
-/* Users show */
-
-.user-info {
-  p {
-    img {
-      width: 170px;
-      height: 170px;
-    }
-  }
-}
-
-
+/***************/
 /* Posts index */
+/***************/
 
 .posts {
   margin: 1.5em 0;
@@ -496,7 +514,10 @@ header {
   }
 }
 
+/***************/
 /* いいねボタン*/
+/***************/
+
 .like {
   text-align: right;
   padding-right: 7px;
@@ -521,13 +542,133 @@ header {
   font-size: 1.3em;
 }
 
+/**************/
+/* Users show */
+/**************/
+
+.user-show-info {
+  margin: .7em auto;
+  max-width: 830px;
+  background-color: white;
+  box-shadow: 0 0 10px rgba(0,0,0,0.15);
+  padding: 1em 1.8em 2em;
+  font-size: 18px;
+  .user-image, .default-user-image {
+    margin-top: 1em;
+    img {
+      width: 180px;
+      height: 180px;
+    }
+  }
+  a {
+    text-decoration: none;
+  }
+  .user-right {
+    padding-left: 3em;
+    .button {
+      text-align: right;
+    }
+    .follow {
+      margin-bottom: 1.2em;
+      #follow_users {
+        padding-right: 1.5em;
+      }
+      #follow_users, #follower_users {
+        display: inline-block;
+        a {
+          color: #2499cf;
+          transition: color 0.1s;
+          &:hover {
+            color : #e0714f;
+          }
+        }
+      }
+    }
+    .post_like {
+      a {
+        margin-bottom: .2em;
+        color: rgb(80, 80, 80);
+        position: relative;
+        display: inline-block;
+        &::after {
+          position: absolute;
+          bottom: -1px;
+          left: 0;
+          content: '';
+          width: 100%;
+          height: 1px;
+          background: rgb(80, 80, 80);
+          transform: scale(0, 1);
+          transform-origin: right top;
+          transition: transform .4s;
+        }
+        &:hover::after {
+          transform-origin: left top;
+          transform: scale(1, 1);
+        }
+      }
+    }
+    h4 {
+      font-size: 25px;
+      margin-bottom: 0.7em;
+    }
+  }
+}
 
 
 
+.user-tab {
+  margin: 0 auto .4em;
+  max-width: 830px;
+    justify-content: space-between;
+    list-style: none;
+    li {
+      font-size: 17px;
+      margin-bottom: 1em;
+      float: left;
+      text-align: center;
+      // box-shadow: 0 0 10px rgba(0,0,0,0.15);
+      a {
+        color: rgb(80, 80, 80);
+        display: block;
+        border: 2px solid rgb(124, 124, 124);
+        border-radius: 2px;
+        &:hover {
+          color: #fff;
+          background: #2499cf;
+          border: 2px solid  #2499cf;
+        }
+        &.current {
+          color: #fff;
+          background: #2499cf;
+          border: 2px solid  #2499cf;
+        }
+      }
+  }
+}
+.user-show-title {
+  margin: 1em auto;
+  max-width: 830px;
+  padding-left: .5em;
+}
+
+.user-show-posts {
+  margin: 1em auto;
+  max-width: 830px;
+}
+
+.user-show-users {
+  margin: 1em auto;
+  max-width: 830px;
+}
+
+
+/**************/
 /* posts#show */
+/**************/
 
 .post-wrapper {
-  max-width: 700px;
+  max-width: 760px;
   margin: 1.8em auto;
   .user-field {
     margin: 0;
@@ -598,7 +739,7 @@ header {
   }
   .post-info {
     margin-top: 5px;;
-    padding-left: 3.8em;
+    padding-left: 3.5em;
     p {
       border-bottom: 1px solid #c2c2c2c5;
       line-height: 2.4em;
@@ -637,7 +778,9 @@ header {
   }
 }
 
+/************/
 /* Comments */
+/************/
 
 .comment-wrapper {
   color: #444;
@@ -735,8 +878,9 @@ header {
 }
 
 
-
+/**************/
 /* pagination */
+/**************/
 
 .pagination {
   margin-top: 1em;
@@ -791,8 +935,9 @@ header {
 // }
 
 
-
-/* footer */
+/************/
+/*  footer  */
+/************/
 
 footer {
   padding: 10px 0 15px 0;
@@ -814,8 +959,9 @@ footer {
   }
 }
 
-
-/* debug */
+/***********/
+/*  debug  */
+/***********/
 
 .debug_dump {
   clear: both;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,19 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, only: [:show, :following, :followers]
-  before_action :set_user, only: [:show, :following, :followers]
+  before_action :authenticate_user!, except: :index
+  before_action :set_user, except: :index
 
   def index
     @users = User.all.page(params[:page]).per(10)
   end
 
   def show
+    @posts = @user.posts.order('updated_at DESC').limit(3)
+
+  end
+
+  def posts
+    @posts = @user.posts.page(params[:page]).per(9)
+    render 'users/posts'
   end
 
   def following
@@ -17,6 +24,16 @@ class UsersController < ApplicationController
   def followers
     @users = @user.followers.page(params[:page]).per(10)
     render 'users/show_follower'
+  end
+
+  def likes
+    @posts = @user.liked_posts.page(params[:page]).per(9)
+    render 'users/likes'
+  end
+
+  def comments
+    @posts = @user.commented_posts.page(params[:page]).per(9)
+    render 'users/comments'
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :commented_posts, through: :comments, source: :post
   has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
   has_many :following_relationships, foreign_key: "follower_id", class_name: "Relationship",  dependent: :destroy

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,28 +6,7 @@
 
 <% @posts.each do |post| %>
   <li class="col-lg-3 col-md-6 col-sm-6 justify-content-around">
-    <div class="post-container">
-      <div class="post-field">
-        <% if post.post_image.present? %>
-          <p class="post-img"><%= image_tag post.post_image_url %></p>
-        <% else %>
-          <p class="post-img default-post-image"><%= image_tag 'no_image200.png' %></p>
-        <% end %>
-        <p class="title"><%= post.title %></p>
-        <p><%= link_to post.title, post %></p>
-      </div>
-      <div class="like" id="index_like_<%= post.id %>">
-        <%= render 'likes/like', post: post %>
-      </div>
-      <div class="bottom-field">
-        <p><%= link_to post.user.nickname, post.user %></p>
-        <% if post.user.image.present? %>
-          <p class="user_small_img"><%= image_tag post.user.image_url(:thumb300) %></p>
-        <% else %>
-          <p class="user_small_img default-user-image"><%= image_tag 'default.png' %></p>
-        <% end %>
-      </div>
-    </div>
+    <%= render partial: 'shared/posts',locals: { post: post } %>
   </li>
 <% end %>
 

--- a/app/views/shared/_posts.html.erb
+++ b/app/views/shared/_posts.html.erb
@@ -1,0 +1,22 @@
+<div class="post-container">
+      <div class="post-field">
+        <% if post.post_image.present? %>
+          <p class="post-img"><%= image_tag post.post_image_url %></p>
+        <% else %>
+          <p class="post-img default-post-image"><%= image_tag 'no_image200.png' %></p>
+        <% end %>
+        <p class="title"><%= post.title %></p>
+        <p><%= link_to post.title, post %></p>
+      </div>
+      <div class="like" id="index_like_<%= post.id %>">
+        <%= render 'likes/like', post: post %>
+      </div>
+      <div class="bottom-field">
+        <p><%= link_to post.user.nickname, post.user %></p>
+        <% if post.user.image.present? %>
+          <p class="user_small_img"><%= image_tag post.user.image_url(:thumb300) %></p>
+        <% else %>
+          <p class="user_small_img default-user-image"><%= image_tag 'default.png' %></p>
+        <% end %>
+      </div>
+    </div>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,4 +1,4 @@
 <%= form_with(model: current_user, url: relationship_path(@user), method: :delete ) do |f|  %>
   <%= hidden_field_tag :following_id, @user.id %>
-  <%= f.submit "フォロー中", class: "btn btn-dark btn" %>
+  <%= f.submit "フォロー中", class: "btn btn-secondary" %>
 <% end %>

--- a/app/views/users/_user_info.html.erb
+++ b/app/views/users/_user_info.html.erb
@@ -1,0 +1,34 @@
+<div class="user-show-info row">
+  <% if @user.image.present? %>
+    <p class="user-image col-4"><%= image_tag @user.image_url(:thumb300) %></p>
+  <% else %>
+    <p class="default-user-image col-4"><%= image_tag 'default.png' %></p>
+  <% end %>
+  <div class="user-right col-8">
+    <div class="button">
+      <% if @user == current_user %>
+        <%= link_to "編集", edit_user_registration_path, class: "btn btn-info" %> 
+      <% else %>
+        <%= render "follow_form" %>
+      <% end %>
+    </div>
+    <h4><%= @user.nickname %></h4>
+    <div class="follow">
+      <div id="follow_users">
+        <%= render "follow_users" %>
+      </div>
+      <div id="follower_users">
+        <%= render "follower_users" %>
+      </div>
+    </div>
+    <div class="post_like">
+      <%= link_to posts_user_path(@user.id) do %>
+        投稿 <%= @user.posts.count %> 件
+      <% end %>
+      <br>
+      <%= link_to likes_user_path(@user.id) do %>
+        いいねした投稿 <%= @user.liked_posts.count %> 件
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/_user_show_posts.html.erb
+++ b/app/views/users/_user_show_posts.html.erb
@@ -1,0 +1,10 @@
+<ul class = "posts user-show-posts row" >
+  <% @posts.each do |post| %>
+    <li class="col-lg-4 col-md-6 col-sm-6 justify-content-around">
+      <%= render partial: 'shared/posts',locals: { post: post } %>
+    </li>
+  <% end %>
+</ul>
+<% if @current != 'top' %>
+  <%= paginate @posts %> 
+<% end %>

--- a/app/views/users/_user_tab.html.erb
+++ b/app/views/users/_user_tab.html.erb
@@ -1,0 +1,32 @@
+<ul class="row user-tab">
+  <% if @current == 'top' %>
+    <li><%= link_to "トップ", user_path(@user.id), class: "btn current" %></li>
+  <% else %>
+    <li><%= link_to "トップ", user_path(@user.id), class: "btn" %></li>
+  <% end %>
+  <% if @current == 'posts' %>
+    <li><%= link_to "投稿一覧", posts_user_path(@user.id), class: "btn current" %></li>
+  <% else %>
+    <li><%= link_to "投稿一覧", posts_user_path(@user.id), class: "btn" %></li>
+  <% end %>
+  <% if @current == 'follow' %>
+    <li><%= link_to "フォロー", following_user_path(@user.id), class: "btn current" %></li>
+  <% else %>
+    <li><%= link_to "フォロー", following_user_path(@user.id), class: "btn" %></li>
+  <% end %>
+  <% if @current == 'followers' %>
+    <li><%= link_to "フォロワー", followers_user_path(@user.id), class: "btn current" %></li>
+  <% else %>
+    <li><%= link_to "フォロワー", followers_user_path(@user.id), class: "btn" %></li>
+  <% end %>
+  <% if @current == 'likes' %>
+    <li><%= link_to "いいね", likes_user_path(@user.id), class: "btn current" %></li>
+  <% else %>
+    <li><%= link_to "いいね", likes_user_path(@user.id), class: "btn" %></li>
+  <% end %>
+  <% if @current == 'comments' %>
+    <li><%= link_to "コメントした投稿", comments_user_path(@user.id), class: "btn current" %></li>
+  <% else %>
+    <li><%= link_to "コメントした投稿", comments_user_path(@user.id), class: "btn" %></li>
+  <% end %>
+</ul>

--- a/app/views/users/_users.html.erb
+++ b/app/views/users/_users.html.erb
@@ -1,0 +1,15 @@
+<% @users.each do |user| %>
+  <li class="col-md-6 col-sm-12">
+    <div class="user-container">
+      <% if user.image.present? %>
+        <p class="img"><%= image_tag user.image_url(:thumb200) %></p>
+      <% else %>
+        <p class="img default-user-image"><%= image_tag 'default.png' %></p>
+      <% end %>
+      <p class="nickname"><%= user.nickname %></p>
+      <p><%= link_to user.nickname, user %></p>
+      <p class="follow">フォロー <span class="pad-r10"><%= user.following.count %></span> フォロワー <span><%= user.followers.count %></span></p>
+      <p class="post">投稿 <span><%= user.posts.count %></span> 件</p>
+    </div>
+  </li>
+<% end %>

--- a/app/views/users/comments.html.erb
+++ b/app/views/users/comments.html.erb
@@ -1,0 +1,8 @@
+<% @title = "#{@user.nickname} コメントした投稿" %>
+<% @current = 'comments' %>
+
+<%= render partial: 'user_tab' %>
+<%= render partial: 'user_info' %>
+
+<h4 class="user-show-title">コメントした投稿 <%= @user.commented_posts.count %> 件</h4>
+<%= render partial: 'user_show_posts' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,19 +3,6 @@
 <h1>ユーザ一覧</h1>
 
 <ul class = "users row" >
-<% @users.each do |user| %>
-  <li class="col-md-6 col-sm-12">
-    <div class="user-container">
-      <% if user.image.present? %>
-        <p class="img"><%= image_tag user.image_url(:thumb200) %></p>
-      <% else %>
-        <p class="img default-user-image"><%= image_tag 'default.png' %></p>
-      <% end %>
-      <p class="nickname"><%= user.nickname %></p>
-      <p><%= link_to user.nickname, user %></p>
-      <p class="follow">フォロー  人  フォロワー  人</p>
-    </div>
-  </li>
-<% end %>
+  <%= render partial: 'users' %>
 </ul>
 <%= paginate @users %>

--- a/app/views/users/likes.html.erb
+++ b/app/views/users/likes.html.erb
@@ -1,0 +1,8 @@
+<% @title = "#{@user.nickname} いいね一覧" %>
+<% @current = 'likes' %>
+
+<%= render partial: 'user_tab' %>
+<%= render partial: 'user_info' %>
+
+<h4 class="user-show-title">いいねした投稿 <%= @user.liked_posts.count %> 件</h4>
+<%= render partial: 'user_show_posts' %>

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -1,0 +1,8 @@
+<% @title = "#{@user.nickname} 投稿一覧" %>
+<% @current = 'posts' %>
+
+<%= render partial: 'user_tab' %>
+<%= render partial: 'user_info' %>
+
+<h4 class="user-show-title">投稿一覧 <%= @user.posts.count %> 件</h4>
+<%= render partial: 'user_show_posts' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,40 +1,8 @@
 <% @title = @user.nickname %>
+<% @current = 'top' %>
 
-<h2>ユーザ情報</h2>
-<div class="user-info">
-  <% if @user.image.present? %>
-    <p><%= image_tag @user.image_url(:thumb300) %></p>
-  <% else %>
-    <p class="default-user-image"><%= image_tag 'default.png' %></p>
-  <% end %>
-  <% if @user == current_user %>
-    <%= link_to "編集", edit_user_registration_path %> 
-  <% else %>
-    <%= render "follow_form" %>
-  <% end %>
-  <p><%= @user.nickname %></p>
-  <div id="follow_users">
-    <%= render "follow_users" %>
-  </div>
-  <div id="follower_users">
-    <%= render "follower_users" %>
-  </div>
+<%= render partial: 'user_tab' %>
+<%= render partial: 'user_info' %>
 
-
-  <%
-=begin%>
- <div id="follow_users">
-    <%= link_to following_user_path(@user.id) do %>
-      <p>フォロー<span><%= @user.following.count %></span></p>
-    <% end %>
-  </div>
-  <div class="follower_users">
-    <%= link_to followers_user_path(@user.id) do %>
-      <p>フォロワー<span><%= @user.followers.count %></span></p>
-    <% end %>
-  </div> 
-<%
-=end%>
-
-
-</div>
+<h4 class="user-show-title">最新の投稿</h4>
+<%= render partial: 'user_show_posts' %>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,1 +1,12 @@
-<p>フォローshowページです</p>
+<% @title = "#{@user.nickname} フォロー" %>
+<% @current = 'follow' %>
+
+<%= render partial: 'user_tab' %>
+<%= render partial: 'user_info' %>
+
+<h4 class="user-show-title">フォロー <%= @user.following.count %> 人</h4>
+<ul class = "users user-show-users row" >
+  <%= render partial: 'users' %>
+</ul>
+<%= paginate @users %>
+

--- a/app/views/users/show_follower.html.erb
+++ b/app/views/users/show_follower.html.erb
@@ -1,1 +1,11 @@
-<p>フォロワーshowページです</p>
+<% @title = "#{@user.nickname} フォロワー" %>
+<% @current = 'followers' %>
+
+<%= render partial: 'user_tab' %>
+<%= render partial: 'user_info' %>
+
+<h4 class="user-show-title">フォロワー <%= @user.followers.count %> 人</h4>
+<ul class = "users user-show-users row" >
+  <%= render partial: 'users' %>
+</ul>
+<%= paginate @users %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     :passwords => 'users/passwords'
   } 
 
+
   devise_scope :user do
     get 'login', :to => 'users/sessions#new'
     get 'logout', :to => 'users/sessions#destroy' 
@@ -15,7 +16,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:index, :show] do
     member do
-      get :following, :followers
+      get :posts, :comments, :following, :followers, :likes
     end
   end
   resources :posts do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe "Users", type: :request do
     user.confirm
     takashi.confirm
   end
-
+  
+  #  -----  index ------  
+  #  -------------------
   describe "GET #index" do
     context "ログインしていないユーザの場合" do
       it "リクエストに成功すること" do
@@ -38,6 +40,8 @@ RSpec.describe "Users", type: :request do
     end
   end
 
+  #  -----  show  ------  
+  #  -------------------
   describe 'GET #show' do
     describe 'ログインしていないユーザのテスト' do
       it "リクエストが失敗すること" do
@@ -67,6 +71,10 @@ RSpec.describe "Users", type: :request do
           get user_path user
           expect(response.body).to include '編集'
         end
+        it '最新の投稿というタイトルが表示されていること' do
+          get user_path user
+          expect(response.body).to include '最新の投稿'
+        end
       end
 
       context '他者のページを表示する場合' do
@@ -82,6 +90,10 @@ RSpec.describe "Users", type: :request do
           get user_path takashi
           expect(response.body).to_not include '編集'
         end
+        it '最新の投稿というタイトルが表示されていること' do
+          get user_path user
+          expect(response.body).to include '最新の投稿'
+        end
       end
 
       context '存在しないユーザのページを表示する場合' do
@@ -90,6 +102,326 @@ RSpec.describe "Users", type: :request do
         end
       end
     end
-
   end
+
+  #  -----  posts ------  
+  #  -------------------
+  describe 'GET #posts' do
+    describe 'ログインしていないユーザのテスト' do
+      it "リクエストが失敗すること" do
+        get posts_user_path user
+        expect(response).to have_http_status 302
+      end
+      it 'ログインページが表示されること' do
+        get posts_user_path user
+        is_expected.to redirect_to new_user_session_path
+      end
+    end
+
+    describe 'ログイン済みのユーザのテスト' do
+      before do
+        sign_in user
+      end
+      context '自身のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get posts_user_path user
+          expect(response.status).to eq 200
+        end
+        it '自身のユーザー名が表示されていること' do
+          get posts_user_path user
+          expect(response.body).to include user.nickname
+        end
+        it '編集ボタンが表示されていること' do
+          get posts_user_path user
+          expect(response.body).to include '編集'
+        end
+        it '投稿一覧というタイトルが表示されていること' do
+          get posts_user_path user
+          expect(response.body).to include '投稿一覧 0 件'
+        end
+      end
+
+      context '他者のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get posts_user_path takashi
+          expect(response.status).to eq 200
+        end
+        it '他者のユーザー名が表示されていること' do
+          get posts_user_path takashi
+          expect(response.body).to include takashi.nickname
+        end
+        it '編集ボタンが表示されていないこと' do
+          get posts_user_path takashi
+          expect(response.body).to_not include '編集'
+        end
+        it '投稿一覧というタイトルが表示されていること' do
+          get posts_user_path user
+          expect(response.body).to include '投稿一覧 0 件'
+        end
+      end
+
+      context '存在しないユーザのページを表示する場合' do
+        it 'エラーが発生すること' do
+          expect{ get "/users/999999/posts" }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
+
+  #  -----following------  
+  #  --------------------
+  describe 'GET #following' do
+    describe 'ログインしていないユーザのテスト' do
+      it "リクエストが失敗すること" do
+        get following_user_path user
+        expect(response).to have_http_status 302
+      end
+      it 'ログインページが表示されること' do
+        get following_user_path user
+        is_expected.to redirect_to new_user_session_path
+      end
+    end
+
+    describe 'ログイン済みのユーザのテスト' do
+      before do
+        sign_in user
+      end
+      context '自身のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get following_user_path user
+          expect(response.status).to eq 200
+        end
+        it '自身のユーザー名が表示されていること' do
+          get following_user_path user
+          expect(response.body).to include user.nickname
+        end
+        it '編集ボタンが表示されていること' do
+          get following_user_path user
+          expect(response.body).to include '編集'
+        end
+        it 'フォローというタイトルが表示されていること' do
+          get following_user_path user
+          expect(response.body).to include 'フォロー 0 人'
+        end
+      end
+
+      context '他者のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get following_user_path takashi
+          expect(response.status).to eq 200
+        end
+        it '他者のユーザー名が表示されていること' do
+          get following_user_path takashi
+          expect(response.body).to include takashi.nickname
+        end
+        it '編集ボタンが表示されていないこと' do
+          get following_user_path takashi
+          expect(response.body).to_not include '編集'
+        end
+        it 'フォローというタイトルが表示されていること' do
+          get following_user_path user
+          expect(response.body).to include 'フォロー 0 人'
+        end
+      end
+
+      context '存在しないユーザのページを表示する場合' do
+        it 'エラーが発生すること' do
+          expect{ get "/users/999999/following" }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
+
+  #  -----followers------  
+  #  --------------------
+  describe 'GET #followers' do
+    describe 'ログインしていないユーザのテスト' do
+      it "リクエストが失敗すること" do
+        get followers_user_path user
+        expect(response).to have_http_status 302
+      end
+      it 'ログインページが表示されること' do
+        get followers_user_path user
+        is_expected.to redirect_to new_user_session_path
+      end
+    end
+
+    describe 'ログイン済みのユーザのテスト' do
+      before do
+        sign_in user
+      end
+      context '自身のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get followers_user_path user
+          expect(response.status).to eq 200
+        end
+        it '自身のユーザー名が表示されていること' do
+          get followers_user_path user
+          expect(response.body).to include user.nickname
+        end
+        it '編集ボタンが表示されていること' do
+          get followers_user_path user
+          expect(response.body).to include '編集'
+        end
+        it 'フォロワーというタイトルが表示されていること' do
+          get followers_user_path user
+          expect(response.body).to include 'フォロワー 0 人'
+        end
+      end
+
+      context '他者のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get followers_user_path takashi
+          expect(response.status).to eq 200
+        end
+        it '他者のユーザー名が表示されていること' do
+          get followers_user_path takashi
+          expect(response.body).to include takashi.nickname
+        end
+        it '編集ボタンが表示されていないこと' do
+          get followers_user_path takashi
+          expect(response.body).to_not include '編集'
+        end
+        it 'フォロワーというタイトルが表示されていること' do
+          get followers_user_path user
+          expect(response.body).to include 'フォロワー 0 人'
+        end
+      end
+
+      context '存在しないユーザのページを表示する場合' do
+        it 'エラーが発生すること' do
+          expect{ get "/users/999999/followers" }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
+
+  #  -----  likes ------  
+  #  -------------------
+  describe 'GET #likes' do
+    describe 'ログインしていないユーザのテスト' do
+      it "リクエストが失敗すること" do
+        get likes_user_path user
+        expect(response).to have_http_status 302
+      end
+      it 'ログインページが表示されること' do
+        get likes_user_path user
+        is_expected.to redirect_to new_user_session_path
+      end
+    end
+
+    describe 'ログイン済みのユーザのテスト' do
+      before do
+        sign_in user
+      end
+      context '自身のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get likes_user_path user
+          expect(response.status).to eq 200
+        end
+        it '自身のユーザー名が表示されていること' do
+          get likes_user_path user
+          expect(response.body).to include user.nickname
+        end
+        it '編集ボタンが表示されていること' do
+          get likes_user_path user
+          expect(response.body).to include '編集'
+        end
+        it 'いいねした投稿というタイトルが表示されていること' do
+          get likes_user_path user
+          expect(response.body).to include 'いいねした投稿 0 件'
+        end
+      end
+
+      context '他者のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get likes_user_path takashi
+          expect(response.status).to eq 200
+        end
+        it '他者のユーザー名が表示されていること' do
+          get likes_user_path takashi
+          expect(response.body).to include takashi.nickname
+        end
+        it '編集ボタンが表示されていないこと' do
+          get likes_user_path takashi
+          expect(response.body).to_not include '編集'
+        end
+        it 'いいねした投稿というタイトルが表示されていること' do
+          get likes_user_path user
+          expect(response.body).to include 'いいねした投稿 0 件'
+        end
+      end
+
+      context '存在しないユーザのページを表示する場合' do
+        it 'エラーが発生すること' do
+          expect{ get "/users/999999/likes" }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
+  
+  #  -----comments------  
+  #  -------------------
+  describe 'GET #comments' do
+    describe 'ログインしていないユーザのテスト' do
+      it "リクエストが失敗すること" do
+        get comments_user_path user
+        expect(response).to have_http_status 302
+      end
+      it 'ログインページが表示されること' do
+        get comments_user_path user
+        is_expected.to redirect_to new_user_session_path
+      end
+    end
+
+    describe 'ログイン済みのユーザのテスト' do
+      before do
+        sign_in user
+      end
+      context '自身のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get comments_user_path user
+          expect(response.status).to eq 200
+        end
+        it '自身のユーザー名が表示されていること' do
+          get comments_user_path user
+          expect(response.body).to include user.nickname
+        end
+        it '編集ボタンが表示されていること' do
+          get comments_user_path user
+          expect(response.body).to include '編集'
+        end
+        it 'コメントした投稿というタイトルが表示されていること' do
+          get comments_user_path user
+          expect(response.body).to include 'コメントした投稿 0 件'
+        end
+      end
+
+      context '他者のページを表示する場合' do
+        it 'リクエストが成功すること' do
+          get comments_user_path takashi
+          expect(response.status).to eq 200
+        end
+        it '他者のユーザー名が表示されていること' do
+          get comments_user_path takashi
+          expect(response.body).to include takashi.nickname
+        end
+        it '編集ボタンが表示されていないこと' do
+          get comments_user_path takashi
+          expect(response.body).to_not include '編集'
+        end
+        it 'コメントした投稿というタイトルが表示されていること' do
+          get comments_user_path user
+          expect(response.body).to include 'コメントした投稿 0 件'
+        end
+      end
+
+      context '存在しないユーザのページを表示する場合' do
+        it 'エラーが発生すること' do
+          expect{ get "/users/999999/comments" }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
+
 end

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Comments', type: :system, js: true, retry: 3 do
   #--------------------
 
   describe "ユーザはコメントをする"  do
+    # たかしでログインする
     before do
       login takashi
       visit post_path hibana
@@ -41,8 +42,16 @@ RSpec.feature 'Comments', type: :system, js: true, retry: 3 do
           expect(page).to have_content 'たかし' 
           expect(page).to have_content '参考になります。' 
         end
+        it 'コメントを送信した投稿が、マイページのコメントした投稿に表示されること' do
+          click_button '送信'
+          wait_for_ajax
+          visit comments_user_path takashi
+          expect(page).to have_content 'コメントした投稿 1 件' 
+          expect(page).to have_content '火花' 
+          expect(page).to have_content 'michael' 
+        end
       end
-      context 'コメント3件以上送信後' do
+      context 'コメント4件送信後' do
         before do
           fill_in 'comment_comment_content', with: '参考になります。'
           click_button '送信'
@@ -66,6 +75,12 @@ RSpec.feature 'Comments', type: :system, js: true, retry: 3 do
           expect(page).to have_content '私も読みました' 
           expect(page).to have_content 'おもしろそうです。' 
           expect(page).to have_content 'お気に入りに追加しました。' 
+        end
+        it 'コメントを送信した投稿が、マイページのコメントした投稿に表示されること' do
+          visit comments_user_path takashi
+          expect(page).to have_content 'コメントした投稿 4 件' 
+          expect(page).to have_content '火花' 
+          expect(page).to have_content 'michael' 
         end
       end
     end
@@ -113,12 +128,21 @@ RSpec.feature 'Comments', type: :system, js: true, retry: 3 do
           wait_for_ajax
         }.to change{ hibana.comments.count }.by(-1)
       end
-      it '削除すると一覧に表示されないこと' do
+      it 'コメントを削除すると一覧に表示されないこと' do
         click_link '削除'
         page.driver.browser.switch_to.alert.accept
         wait_for_ajax
         expect(page).to have_content 'コメントはまだありません' 
         expect(page).to_not have_content 'たかし' 
+      end
+      it 'コメントを削除すると、マイページのコメントした投稿に表示されないこと' do
+        click_link '削除'
+        page.driver.browser.switch_to.alert.accept
+        wait_for_ajax
+        visit comments_user_path takashi
+        expect(page).to have_content 'コメントした投稿 0 件' 
+        expect(page).to_not have_content '火花' 
+        expect(page).to_not have_content 'michael' 
       end
     end
 

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -11,8 +11,9 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
 
   describe 'ユーザは投稿にいいねをする' do
     context 'ログインユーザの場合' do
+      # michaelでログインする
       before { login michael }
-      it '投稿一覧でのいいねが成功し、いいねの数が増える' do
+      it '投稿一覧でハートのアイコンをクリックすると、いいねの数が増える' do
         visit posts_path
         expect {
           find('.fa-heart').click
@@ -24,7 +25,7 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
         expect(find(".fa-heart")).to have_content "1"
         expect(page).to have_css('.like-red')
       end
-      it '投稿詳細でのいいねが成功し、いいねの数が増える' do
+      it '投稿詳細でハートのアイコンをクリックすると、いいねの数が増える' do
         visit post_path hibana
         expect {
           find('.fa-heart').click
@@ -35,6 +36,24 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
         visit posts_path
         expect(find(".fa-heart")).to have_content "1"
         expect(page).to have_css('.like-red')
+      end
+      it '投稿一覧でいいねした投稿がマイページのいいねした投稿ページに表示される' do
+        visit posts_path
+        find('.fa-heart').click
+        wait_for_ajax
+        visit user_path michael
+        click_link 'いいね'
+        expect(page).to have_content 'いいねした投稿 1 件'
+        expect(page).to have_content '火花'
+      end
+      it '投稿詳細でいいねした投稿がマイページのいいねした投稿ページに表示される' do
+        visit post_path hibana
+        find('.fa-heart').click
+        wait_for_ajax
+        visit user_path michael
+        click_link 'いいね'
+        expect(page).to have_content 'いいねした投稿 1 件'
+        expect(page).to have_content '火花'
       end
     end
     context 'ログイしていないユーザの場合' do
@@ -58,7 +77,7 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
       wait_for_ajax
     end
     context 'ログインユーザの場合' do
-      it '投稿一覧でのいいねの取り消しが成功し、いいねの数が減る' do
+      it '投稿一覧でハートのアイコンをクリックすると、いいねの数が減る' do
         expect(find(".fa-heart")).to have_content "1"
         expect(page).to have_css('.like-red')
         visit posts_path
@@ -72,7 +91,7 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
         expect(find(".fa-heart")).to have_content "0"
         expect(page).to_not have_css('.like-red')
       end
-      it '投稿詳細でのいいねの取り消しが成功し、いいねの数が減る' do
+      it '投稿詳細でハートのアイコンをクリックすると、いいねの数が減る' do
         visit post_path hibana
         expect(find(".fa-heart")).to have_content "1"
         expect(page).to have_css('.like-red')
@@ -85,6 +104,24 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
         visit posts_path
         expect(find(".fa-heart")).to have_content "0"
         expect(page).to_not have_css('.like-red')
+      end
+      it '投稿一覧でいいねを取り消した投稿がマイページのいいねした投稿ページに表示されない' do
+        visit posts_path
+        find('.fa-heart').click
+        wait_for_ajax
+        visit user_path michael
+        click_link 'いいね'
+        expect(page).to have_content 'いいねした投稿 0 件'
+        expect(page).to_not have_content '火花'
+      end
+      it '投稿詳細でいいねを取り消した投稿がマイページのいいねした投稿ページに表示されない' do
+        visit post_path hibana
+        find('.fa-heart').click
+        wait_for_ajax
+        visit user_path michael
+        click_link 'いいね'
+        expect(page).to have_content 'いいねした投稿 0 件'
+        expect(page).to_not have_content '火花'
       end
     end
     context 'ログインしていないユーザの場合' do

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Posts', type: :system do
   let!(:kenji) { create(:kenji) }
   before do
     kenji.confirm
+    # けんじでログインする
     login kenji
   end 
 
@@ -39,11 +40,22 @@ RSpec.feature 'Posts', type: :system do
         expect(page).to have_content '投稿されました。'
         expect(current_path).to eq new_post_path
       end
-      it "投稿が、投稿一覧に表示されること" do
+      it "投稿が、本を探すの投稿一覧に表示されること" do
         click_button '投稿する'
         visit posts_path
         expect(page).to have_content '流浪の月' 
         expect(page).to have_content 'けんじ' 
+      end
+      it "投稿が、マイページの最新の投稿に表示されること" do
+        click_button '投稿する'
+        visit user_path kenji
+        expect(page).to have_content '流浪の月'
+      end
+      it "投稿が、マイページの投稿一覧に表示されること" do
+        click_button '投稿する'
+        visit  posts_user_path kenji
+        expect(page).to have_content '投稿一覧 1 件'
+        expect(page).to have_content '流浪の月'
       end
       it "投稿した情報が、投稿の詳細ページに表示されること" do
         click_button '投稿する'
@@ -166,12 +178,23 @@ RSpec.feature 'Posts', type: :system do
         expect(page).to have_content '投稿は更新されました。'
         expect(current_path).to eq post_path kenji.posts.last
       end
-      it "更新したタイトルが投稿一覧に表示されること" do
+      it "更新したタイトルが本を探すの投稿一覧に表示されること" do
         click_button '更新する'
         visit posts_path
         expect(page).to have_content '逆ソクラテス' 
         expect(page).to_not have_content '流浪の月' 
         expect(page).to have_content 'けんじ' 
+      end
+      it "更新した投稿が、マイページの最新の投稿に表示されること" do
+        click_button '更新する'
+        visit user_path kenji
+        expect(page).to have_content '逆ソクラテス'
+      end
+      it "更新した投稿が、マイページの投稿一覧に表示されること" do
+        click_button '更新する'
+        visit  posts_user_path kenji
+        expect(page).to have_content '投稿一覧 1 件'
+        expect(page).to have_content '逆ソクラテス'
       end
       it "更新した情報が、投稿の詳細ページに表示されること" do
         click_button '更新する'
@@ -312,11 +335,26 @@ RSpec.feature 'Posts', type: :system do
       expect(page).to have_content '投稿は削除されました。'
       expect(current_path).to eq user_path kenji
     end
-    it "削除した投稿が投稿一覧に表示されていないこと" do
+    it "削除した投稿が本を探すの投稿一覧に表示されないこと" do
       click_link '投稿を削除する'
       page.driver.browser.switch_to.alert.accept
       visit posts_path
       expect(page).to_not have_content '流浪の月' 
+    end
+    it "削除した投稿が、マイページの最新の投稿に表示されないこと" do
+      click_link '投稿を削除する'
+      page.driver.browser.switch_to.alert.accept
+      wait_for_ajax
+      visit user_path kenji
+      expect(page).to_not have_content '逆ソクラテス'
+    end
+    it "削除した投稿が、マイページの投稿一覧に表示されないこと" do
+      click_link '投稿を削除する'
+      page.driver.browser.switch_to.alert.accept
+      wait_for_ajax
+      visit  posts_user_path kenji
+      expect(page).to have_content '投稿一覧 0 件'
+      expect(page).to_not have_content '逆ソクラテス'
     end
   end
 

--- a/spec/system/relationship_spec.rb
+++ b/spec/system/relationship_spec.rb
@@ -38,20 +38,28 @@ RSpec.feature 'Relationship', type: :system, js: true, retry: 3 do
       visit user_path michael
       expect(page).to have_content 'フォロー 1'
     end
-    xit 'ユーザ一覧ページのフォロー・フォロワー数の表示が変わること' do
+    it 'ユーザ一覧ページのフォロー・フォロワー数の表示が変わること' do
       click_button 'フォローする'
       wait_for_ajax
-
+      visit users_path
+      expect(page).to have_content 'フォロー 1 フォロワー 0'
+      expect(page).to have_content 'フォロー 0 フォロワー 1'
     end
-    xit 'michaelのフォロー一覧に、たかしが表示されること' do
+    it 'michaelのフォロー一覧に、たかしが表示されること' do
       click_button 'フォローする'
       wait_for_ajax
-
+      visit user_path michael
+      click_link 'フォロー'
+      expect(page).to have_content 'フォロー 1 人'
+      expect(page).to have_content 'たかし'
     end
-    xit 'たかしのフォロー一覧に、michaelが表示されること' do
+    it 'たかしのフォロー一覧に、michaelが表示されること' do
       click_button 'フォローする'
       wait_for_ajax
-
+      visit user_path takashi
+      click_link 'フォロワー'
+      expect(page).to have_content 'フォロワー 1 人'
+      expect(page).to have_content 'michael'
     end
   end
 
@@ -87,21 +95,28 @@ RSpec.feature 'Relationship', type: :system, js: true, retry: 3 do
       visit user_path michael
       expect(page).to have_content 'フォロー 0'
     end
-
-    xit 'ユーザ一覧ページのフォロワー数の表示が変わること' do
+    it 'ユーザ一覧ページのフォロワー数の表示が変わること' do
       click_button 'フォロー中'
       wait_for_ajax
-
+      visit users_path
+      expect(page).to have_content 'フォロー 0 フォロワー 0'
+      expect(page).to have_content 'フォロー 0 フォロワー 0'
     end
-    xit 'michaelのフォロー一覧に、たかしが表示されないこと' do
+    it 'michaelのフォロー一覧に、たかしが表示されないこと' do
       click_button 'フォロー中'
       wait_for_ajax
-
+      visit user_path michael
+      click_link 'フォロー'
+      expect(page).to have_content 'フォロー 0 人'
+      expect(page).to_not have_content 'たかし'
     end
-    xit 'たかしのフォロー一覧に、michaelが表示されないこと' do
+    it 'たかしのフォロー一覧に、michaelが表示されないこと' do
       click_button 'フォロー中'
       wait_for_ajax
-
+      visit user_path takashi
+      click_link 'フォロワー'
+      expect(page).to have_content 'フォロワー 0 人'
+      expect(page).to_not have_content 'michael'
     end
   end
 


### PR DESCRIPTION
### 内容
・ユーザ一覧にフォロー数・フォロワー数を表示
・userコントローラにposts　following　followers　likes　commentsを追加
・ユーザページに、最新の投稿・投稿一覧・フォロー一覧・フォロワー一覧・いいね一覧・コメントした投稿一覧を表示
・system specを追加
Close #28 Close #48 Close #51