### PR TITLE
いいねしたユーザページの作成

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -520,7 +520,7 @@ header {
 
 .like {
   text-align: right;
-  padding-right: 7px;
+  padding-right: 6px;
   .fa-heart {
     &:hover {
       opacity: 0.7;
@@ -704,22 +704,43 @@ header {
       margin-right: .5em;
     }
   }
-  
-  h2 {
-    font-size:1.4em;
-    margin: 0 0 .8em;
+  .post-title {
+    h2 {
+      font-size:1.4em;
+      line-height: 1.1em;
+      margin: 0;
+    }
+    .title-top {
+      font-size: 14px;
+      text-align: center;
+      color: #6e6e6e;
+    }
   }
-  .title-top {
-    font-size: 13px;
-    text-align: center;
-    color: #6e6e6e;
+  .post-show-like {
+    display: flex;
+    justify-content: flex-end;
+    align-items: flex-end;
+    padding: 0;
+  }
+  .liked_users {
+    text-align: right;
+    margin: 0 0 1.2em;
+    a {
+      text-decoration: none;
+      color: #464a7a;
+      text-decoration: none;
+      transition: color 0.2s;
+      &:hover {
+        color : #e0714f;
+      }
+    }
   }
   .post-image {
-    box-shadow: 0 0 15px rgba(0,0,0,0.15);
+    // box-shadow: 0 0 15px rgba(0,0,0,0.10);
     text-align: center;
     padding: 10px;
     // background-color: #f1f1f1;
-    background-color: #fff;
+    background-color: transparent;
     text-align: center;
     margin: 0 auto;
     position: relative;
@@ -733,25 +754,42 @@ header {
       right: 0;
       height: auto;
       width: auto;
-      max-height: 88%;
+      max-height: 95%;
       margin: auto;
     }
   }
   .post-info {
-    margin-top: 5px;;
-    padding-left: 3.5em;
-    p {
-      border-bottom: 1px solid #c2c2c2c5;
-      line-height: 2.4em;
-      font-size: 16px;
+    margin-top: .5em;
+    padding-left: 1.5em;
+    border-collapse: separate;
+    width: 100%;
+    tr {
+      line-height: 1.15em;
     }
-    span {
-      font-size: 12.5px;
+    th {
+      font-size: 14px;
+      font-weight: 500;
       color: #6e6e6e;
-      display: inline-block;
-      padding-left: 1.1em;
-      width: 155px;
+      width: 20%;
+      padding-bottom: 18px;
+      text-align: right;
+
     }
+    td {
+      padding-left: 15px;
+      padding-bottom: 18px;
+      // line-height: 2.4em;
+      font-size: 17px;
+      width: 80%;
+    }
+
+    // span {
+    //   font-size: 12.5px;
+    //   color: #6e6e6e;
+    //   display: inline-block;
+    //   padding-left: 1.1em;
+    //   width: 155px;
+    // }
   }
 
   .post-content-container {
@@ -777,6 +815,74 @@ header {
     }
   }
 }
+
+.show-liked-users {
+  max-width: 850px;
+  margin: 0 auto;
+  .post-field {
+    margin-top: 3em;
+    .user_small_img {
+      display: inline-block;
+      img {
+        width: 55px;
+        height: 55px;
+        border-radius: 50%;
+        border: 1px solid rgba(204, 204, 204, 0.555);
+      }
+    }
+    p.user-name {
+      display: inline-block;
+      a {
+        color: #2499cf;
+        text-decoration: none;
+        transition: color 0.2s;
+        &:hover {
+          color : #e0714f;
+        }
+      }
+    }
+    h5, p {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .post-image {
+      text-align: center;
+      // padding: 10px;
+      text-align: center;
+      position: relative;
+      width: 220px;
+      height: 220px;
+      img {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: auto;
+        width: auto;
+        max-height: 95%;
+      }
+    }
+    h5 {
+      font-size: 18px;
+      margin-top: .8em;
+      margin-bottom: 0;
+    }
+    .author {
+      font-size: 15px;
+      margin-bottom: .5em;
+    }
+  }
+  .liked-users-field {
+    padding-left: 2em;
+    h4 {
+      padding-left: 1em;
+    }
+  }
+}
+
+
 
 /************/
 /* Comments */

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: :index
-  before_action :set_post, only: [:show, :edit, :update]
+  before_action :set_post, only: [:show, :edit, :update, :liked_users]
   before_action :correct_user, only: [:edit, :update, :destroy]
 
   def index
@@ -42,6 +42,11 @@ class PostsController < ApplicationController
     @post.destroy
     flash[:notice] = "投稿は削除されました。"
     redirect_to @post.user
+  end
+
+  def liked_users
+    @users = @post.liked_users.page(params[:page]).per(20)
+    render 'posts/liked_users'
   end
 
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,9 +8,9 @@ class Post < ApplicationRecord
 
   default_scope -> { order(created_at: :desc) }
 
-  validates :title, presence: true, length: { maximum: 200 }
-  validates :author, presence: true, length: { maximum: 100 }
-  validates :publisher, length: { maximum: 100 }
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :author, presence: true, length: { maximum: 60 }
+  validates :publisher, length: { maximum: 60 }
   validates :genre, inclusion: {
     in: %w(not_select novel business education art_ent celebrity hobby geography child others)
   }

--- a/app/views/posts/liked_users.html.erb
+++ b/app/views/posts/liked_users.html.erb
@@ -1,0 +1,26 @@
+<% @current_page = 'liked_users'   %>
+
+<div class="show-liked-users row">
+  <div class="post-field col-3">
+    <% if @post.user.image.present? %>
+          <p class="user_small_img"><%= image_tag @post.user.image_url(:thumb200) %></p>
+        <% else %>
+          <p class="user_small_img default-user-image"><%= image_tag 'default.png' %></p>
+        <% end %>
+    <p class="user-name"><%= link_to @post.user.nickname, @post.user %></p>
+    <h5><%= @post.title %></h5>
+    <p class="author">著) <%= @post.author %></p>
+    <% if @post.post_image.present? %>
+      <p class="post-image"><%= image_tag @post.post_image_url %></p>
+    <% else %>
+      <p class="post-image default-post-image"><%= image_tag 'no_image200.png' %></p>
+    <% end %>
+  </div>
+  <div class="liked-users-field col-9">
+    <h4>いいねしたユーザ <%= @post.liked_users.count %> 人</h4>
+    <ul class = "users user-show-users row" >
+  <%= render partial: 'users/users' %>
+</ul>
+<%= paginate @users %>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,25 +15,29 @@
         <% end %>
       </div>
   <% end %>
-  <p class="col-11 title-top">タイトル</p>
-  <h2 class="col-11"><%= @post.title %></h2>
-  <div class="like normal" id="show_like_<%= @post.id %>">
-    <%= render 'likes/like', post: @post %>
+  <div class="post-title col-md-11 col-10">
+    <p class="title-top">タイトル</p>
+    <h2><%= @post.title %></h2>
   </div>
+  <div class="post-show-like col-md-1 col-2">
+    <div class="like normal" id="show_like_<%= @post.id %>">
+      <%= render 'likes/like', post: @post %>
+    </div>
+  </div>
+  <p class="liked_users col-12"><%= link_to "いいねしたユーザ", liked_users_post_path(@post) %></p>
   <% if @post.post_image.present? %>
     <p class="post-image col-4"><%= image_tag @post.post_image_url %></p>
   <% else %>
     <p class="post-image col-4 default-post-image"><%= image_tag 'no_image200.png' %></p>
   <% end %>
-  </p>
-  <div class="post-info col-8">
-    <p><span>著者</span><%= @post.author %></p>
-    <p><span>出版社</span><%= @post.publisher %></p>
-    <p><span>ジャンル</span><%= @post.genre_i18n %></p>
-    <p><span>評価</span><%= @post.rating_i18n %></p>
-    <p><span>読むのにかかった時間</span><%= @post.hours_i18n %></p>
-    <p><span>購入日</span><%= @post.purchase_date %></p>
-  </div>
+  <table class="post-info col-8">
+    <tr><th>著者</th><td><%= @post.author %></td></tr>
+    <tr><th>出版社</th><td><%= @post.publisher %></td></tr>
+    <tr><th>ジャンル</th><td><%= @post.genre_i18n %></td></tr>
+    <tr><th>評価</th><td><%= @post.rating_i18n %></td></tr>
+    <tr><th>読書時間</th><td><%= @post.hours_i18n %></td></tr>
+    <tr><th>購入日</th><td><%= @post.purchase_date %></td></tr>
+  </table>
   <div class="post-content-container col-12">
     <p class="post-content-top">感想</p>
     <p class="post-content"><%= @post.post_content %></p>

--- a/app/views/users/_users.html.erb
+++ b/app/views/users/_users.html.erb
@@ -1,5 +1,9 @@
 <% @users.each do |user| %>
+  <% if @current_page == 'liked_users' %>
+  <li class="col-12">
+  <%else%>
   <li class="col-md-6 col-sm-12">
+  <% end %>
     <div class="user-container">
       <% if user.image.present? %>
         <p class="img"><%= image_tag user.image_url(:thumb200) %></p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -37,7 +37,7 @@ ja:
         publisher: "出版社"
         genre: "ジャンル"
         rating: "評価"
-        hours: "読むのにかかった時間"
+        hours: "読書時間"
         purchase_date: "購入日"
         post_content: "感想"
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
     :passwords => 'users/passwords'
   } 
 
-
   devise_scope :user do
     get 'login', :to => 'users/sessions#new'
     get 'logout', :to => 'users/sessions#destroy' 
@@ -22,6 +21,9 @@ Rails.application.routes.draw do
   resources :posts do
     resources :comments, only: [:create, :edit, :update, :destroy]
     resource :likes, only: [:create, :destroy]
+    member do
+      get :liked_users
+    end
   end
   resources :relationships, only: [:create, :destroy]
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe Post, type: :model do
     expect(post.errors[:title]).to include("を入力してください")
   end
 
-  it "タイトルが200文字以内であれば有効であること" do
-    char200 = "a" * 200
-    post = FactoryBot.build(:post, title: char200)
+  it "タイトルが100文字以内であれば有効であること" do
+    char100 = "a" * 100
+    post = FactoryBot.build(:post, title: char100)
     expect(post).to be_valid
   end
 
-  it "タイトルが201文字以上であれば無効であること" do
-    char201 = "a" * 201
-    post = FactoryBot.build(:post, title: char201)
+  it "タイトルが101文字以上であれば無効であること" do
+    char101 = "a" * 101
+    post = FactoryBot.build(:post, title: char101)
     post.valid?
-    expect(post.errors[:title]).to include("は200文字以内で入力してください")
+    expect(post.errors[:title]).to include("は100文字以内で入力してください")
   end
   
   it "著者がnilであれば無効であること" do
@@ -32,30 +32,30 @@ RSpec.describe Post, type: :model do
     expect(post.errors[:author]).to include("を入力してください")
   end
 
-  it "著者が100文字以内であれば有効であること" do
-    char100 = "a" * 100
-    post = FactoryBot.build(:post, author: char100)
+  it "著者が60文字以内であれば有効であること" do
+    char60 = "a" * 60
+    post = FactoryBot.build(:post, author: char60)
     expect(post).to be_valid
   end
 
-  it "著者が101文字以上であれば無効であること" do
-    char101 = "a" * 101
-    post = FactoryBot.build(:post, author: char101)
+  it "著者が61文字以上であれば無効であること" do
+    char61 = "a" * 61
+    post = FactoryBot.build(:post, author: char61)
     post.valid?
-    expect(post.errors[:author]).to include("は100文字以内で入力してください")
+    expect(post.errors[:author]).to include("は60文字以内で入力してください")
   end
 
-  it "出版社が100文字以内であれば有効であること" do
-    char100 = "a" * 100
-    post = FactoryBot.build(:post, publisher: char100)
+  it "出版社が60文字以内であれば有効であること" do
+    char60 = "a" * 60
+    post = FactoryBot.build(:post, publisher: char60)
     expect(post).to be_valid
   end
 
-  it "出版社が101文字以上であれば無効であること" do
-    char101 = "a" * 101
-    post = FactoryBot.build(:post, publisher: char101)
+  it "出版社が61文字以上であれば無効であること" do
+    char61 = "a" * 61
+    post = FactoryBot.build(:post, publisher: char61)
     post.valid?
-    expect(post.errors[:publisher]).to include("は100文字以内で入力してください")
+    expect(post.errors[:publisher]).to include("は60文字以内で入力してください")
   end
 
   it "ジャンルがnilであれば無効であること" do
@@ -165,48 +165,48 @@ RSpec.describe Post, type: :model do
     expect(post).to be_valid
   end
 
-  it "読むのにかかった時間がnilであれば無効であること" do
+  it "読書時間がnilであれば無効であること" do
     post = FactoryBot.build(:post, hours: nil)
     post.valid?
     expect(post.errors[:hours]).to include("は一覧にありません")
   end
 
-  it "読むのにかかった時間が〜10時間であれば有効であること" do
+  it "読書時間が〜10時間であれば有効であること" do
     post = FactoryBot.build(:post, hours:"to10" )
     expect(post).to be_valid
   end
 
-  it "読むのにかかった時間が10〜20時間であれば有効であること" do
+  it "読書時間が10〜20時間であれば有効であること" do
     post = FactoryBot.build(:post, hours:"to20" )
     expect(post).to be_valid
   end
 
-  it "読むのにかかった時間が20〜30時間であれば有効であること" do
+  it "読書時間が20〜30時間であれば有効であること" do
     post = FactoryBot.build(:post, hours:"to30" )
     expect(post).to be_valid
   end
 
-  it "読むのにかかった時間が30〜40時間であれば有効であること" do
+  it "読書時間が30〜40時間であれば有効であること" do
     post = FactoryBot.build(:post, hours:"to40" )
     expect(post).to be_valid
   end
 
-  it "読むのにかかった時間が40〜50時間であれば有効であること" do
+  it "読書時間が40〜50時間であれば有効であること" do
     post = FactoryBot.build(:post, hours:"to50" )
     expect(post).to be_valid
   end
 
-  it "読むのにかかった時間が50〜70時間であれば有効であること" do
+  it "読書時間が50〜70時間であれば有効であること" do
     post = FactoryBot.build(:post, hours:"to70" )
     expect(post).to be_valid
   end
 
-  it "読むのにかかった時間が70〜100時間であれば有効であること" do
+  it "読書時間が70〜100時間であれば有効であること" do
     post = FactoryBot.build(:post, hours:"to100" )
     expect(post).to be_valid
   end
 
-  it "読むのにかかった時間が100時間以上であれば有効であること" do
+  it "読書時間が100時間以上であれば有効であること" do
     post = FactoryBot.build(:post, hours:"from100" )
     expect(post).to be_valid
   end

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
 
   describe 'ユーザは投稿にいいねをする' do
     context 'ログインユーザの場合' do
-      # michaelでログインする
-      before { login michael }
+      # たかしでログインする
+      before { login takashi }
       it '投稿一覧でハートのアイコンをクリックすると、いいねの数が増える' do
         visit posts_path
         expect {
@@ -41,7 +41,7 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
         visit posts_path
         find('.fa-heart').click
         wait_for_ajax
-        visit user_path michael
+        visit user_path takashi
         click_link 'いいね'
         expect(page).to have_content 'いいねした投稿 1 件'
         expect(page).to have_content '火花'
@@ -50,10 +50,21 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
         visit post_path hibana
         find('.fa-heart').click
         wait_for_ajax
-        visit user_path michael
+        visit user_path takashi
         click_link 'いいね'
         expect(page).to have_content 'いいねした投稿 1 件'
         expect(page).to have_content '火花'
+      end
+      it 'いいねをしたユーザが、いいねしたユーザページに表示される' do
+        visit post_path hibana
+        find('.fa-heart').click
+        wait_for_ajax
+        click_link 'いいねしたユーザ'
+        expect(page).to have_content 'michael'
+        expect(page).to have_content '火花'
+        expect(page).to have_content '又吉直樹'
+        expect(page).to have_content 'いいねしたユーザ 1 人'
+        expect(page).to have_content 'たかし'
       end
     end
     context 'ログイしていないユーザの場合' do
@@ -70,6 +81,7 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
   end
 
   describe 'ユーザは投稿へのいいね取り消す' do
+    # たかしでログイン
     before do
       login takashi
       visit posts_path
@@ -122,6 +134,17 @@ RSpec.feature 'Likes', type: :system, js: true, retry: 3 do
         click_link 'いいね'
         expect(page).to have_content 'いいねした投稿 0 件'
         expect(page).to_not have_content '火花'
+      end
+      it 'いいねを取り消したユーザが、いいねしたユーザページに表示されない' do
+        visit post_path hibana
+        find('.fa-heart').click
+        wait_for_ajax
+        click_link 'いいねしたユーザ'
+        expect(page).to have_content 'michael'
+        expect(page).to have_content '火花'
+        expect(page).to have_content '又吉直樹'
+        expect(page).to have_content 'いいねしたユーザ 0 人'
+        expect(page).to_not have_content 'たかし'
       end
     end
     context 'ログインしていないユーザの場合' do

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -115,26 +115,26 @@ RSpec.feature 'Posts', type: :system do
         expect(page).to have_content 'タイトルを入力してください'
         expect(page).to have_content '著者を入力してください'
       end
-      it "タイトルが201文字以上の場合、エラーメッセージが表示されること" do
-        char201 = 'a' * 201
-        fill_in 'post_title', with: char201
-        click_button '投稿する'
-        expect(page).to have_content '投稿 は保存されませんでした。'
-        expect(page).to have_content 'タイトルは200文字以内で入力してください'
-      end
-      it "著者が101文字以上の場合、エラーメッセージが表示されること" do
+      it "タイトルが101文字以上の場合、エラーメッセージが表示されること" do
         char101 = 'a' * 101
-        fill_in 'post_author', with: char101
+        fill_in 'post_title', with: char101
         click_button '投稿する'
         expect(page).to have_content '投稿 は保存されませんでした。'
-        expect(page).to have_content '著者は100文字以内で入力してください'
+        expect(page).to have_content 'タイトルは100文字以内で入力してください'
       end
-      it "出版社が101文字以上の場合、エラーメッセージが表示されること" do
-        char101 = 'a' * 101
-        fill_in 'post_publisher', with: char101
+      it "著者が61文字以上の場合、エラーメッセージが表示されること" do
+        char61 = 'a' * 61
+        fill_in 'post_author', with: char61
         click_button '投稿する'
         expect(page).to have_content '投稿 は保存されませんでした。'
-        expect(page).to have_content '出版社は100文字以内で入力してください'
+        expect(page).to have_content '著者は60文字以内で入力してください'
+      end
+      it "出版社が61文字以上の場合、エラーメッセージが表示されること" do
+        char61 = 'a' * 61
+        fill_in 'post_publisher', with: char61
+        click_button '投稿する'
+        expect(page).to have_content '投稿 は保存されませんでした。'
+        expect(page).to have_content '出版社は60文字以内で入力してください'
       end
       it "感想が1001文字以上の場合、エラーメッセージが表示されること" do
         char1001 = 'a' * 1001
@@ -250,26 +250,26 @@ RSpec.feature 'Posts', type: :system do
         expect(page).to have_content 'タイトルを入力してください'
         expect(page).to have_content '著者を入力してください'
       end
-      it "タイトルが201文字以上の場合、エラーメッセージが表示されること" do
-        char201 = 'a' * 201
-        fill_in 'post_title', with: char201
-        click_button '更新する'
-        expect(page).to have_content '投稿 は保存されませんでした。'
-        expect(page).to have_content 'タイトルは200文字以内で入力してください'
-      end
-      it "著者が101文字以上の場合、エラーメッセージが表示されること" do
+      it "タイトルが101文字以上の場合、エラーメッセージが表示されること" do
         char101 = 'a' * 101
-        fill_in 'post_author', with: char101
+        fill_in 'post_title', with: char101
         click_button '更新する'
         expect(page).to have_content '投稿 は保存されませんでした。'
-        expect(page).to have_content '著者は100文字以内で入力してください'
+        expect(page).to have_content 'タイトルは100文字以内で入力してください'
       end
-      it "出版社が101文字以上の場合、エラーメッセージが表示されること" do
-        char101 = 'a' * 101
-        fill_in 'post_publisher', with: char101
+      it "著者が61文字以上の場合、エラーメッセージが表示されること" do
+        char61 = 'a' * 61
+        fill_in 'post_author', with: char61
         click_button '更新する'
         expect(page).to have_content '投稿 は保存されませんでした。'
-        expect(page).to have_content '出版社は100文字以内で入力してください'
+        expect(page).to have_content '著者は60文字以内で入力してください'
+      end
+      it "出版社が61文字以上の場合、エラーメッセージが表示されること" do
+        char61 = 'a' * 61
+        fill_in 'post_publisher', with: char61
+        click_button '更新する'
+        expect(page).to have_content '投稿 は保存されませんでした。'
+        expect(page).to have_content '出版社は60文字以内で入力してください'
       end
       it "感想が1001文字以上の場合、エラーメッセージが表示されること" do
         char1001 = 'a' * 1001


### PR DESCRIPTION
### 内容
・postモデルのバリデーションの変更（文字数の制限を少なく設定）
・投稿詳細ページのcssの改善
・いいねしたユーザページの作成
・上記ページ作成に関するpostのテストの追加
Close #62 Close #64